### PR TITLE
Adds export-key implementation

### DIFF
--- a/command_set.go
+++ b/command_set.go
@@ -239,17 +239,17 @@ func (cs *CommandSet) DeriveKey(path string) error {
 func (cs *CommandSet) ExportKey(derive bool, makeCurrent bool, onlyPublic bool, path string) ([]byte, error) {
 	var p1 uint8
 	if (derive == false) {
-		p1 = 0x00
+		p1 = types.EXPORT_KEY_CURRENT
 	} else if (makeCurrent == false) {
-		p1 = 0x01
+		p1 = types.EXPORT_KEY_DERIVE
 	} else {
-		p1 = 0x02
+		p1 = types.EXPORT_KEY_DERIVE_AND_MAKE_CURRENT
 	}
 	var p2 uint8
 	if (onlyPublic == true) {
-		p2 = 0x01
+		p2 = types.EXPORT_KEY_PUB
 	} else {
-		p2 = 0x00
+		p2 = types.EXPORT_KEY_PRIV_PUB
 	}
 	cmd, err := NewCommandExportKey(p1, p2, path)
 	if err != nil {
@@ -257,7 +257,6 @@ func (cs *CommandSet) ExportKey(derive bool, makeCurrent bool, onlyPublic bool, 
 	}	
 
 	resp, err := cs.sc.Send(cmd)
-	// fmt.Printf("res.Data: %x\n", resp.Data)
 	err = cs.checkOK(resp, err)
 	if err != nil {
 		return nil, err

--- a/command_set.go
+++ b/command_set.go
@@ -239,17 +239,17 @@ func (cs *CommandSet) DeriveKey(path string) error {
 func (cs *CommandSet) ExportKey(derive bool, makeCurrent bool, onlyPublic bool, path string) ([]byte, error) {
 	var p1 uint8
 	if (derive == false) {
-		p1 = types.EXPORT_KEY_CURRENT
+		p1 = EXPORT_KEY_CURRENT
 	} else if (makeCurrent == false) {
-		p1 = types.EXPORT_KEY_DERIVE
+		p1 = EXPORT_KEY_DERIVE
 	} else {
-		p1 = types.EXPORT_KEY_DERIVE_AND_MAKE_CURRENT
+		p1 = EXPORT_KEY_DERIVE_AND_MAKE_CURRENT
 	}
 	var p2 uint8
 	if (onlyPublic == true) {
-		p2 = types.EXPORT_KEY_PUB
+		p2 = EXPORT_KEY_PUB
 	} else {
-		p2 = types.EXPORT_KEY_PRIV_PUB
+		p2 = EXPORT_KEY_PRIV_PUB
 	}
 	cmd, err := NewCommandExportKey(p1, p2, path)
 	if err != nil {

--- a/command_set.go
+++ b/command_set.go
@@ -236,6 +236,36 @@ func (cs *CommandSet) DeriveKey(path string) error {
 	return cs.checkOK(resp, err)
 }
 
+func (cs *CommandSet) ExportKey(derive bool, makeCurrent bool, onlyPublic bool, path string) ([]byte, error) {
+	var p1 uint8
+	if (derive == false) {
+		p1 = 0x00
+	} else if (makeCurrent == false) {
+		p1 = 0x01
+	} else {
+		p1 = 0x02
+	}
+	var p2 uint8
+	if (onlyPublic == true) {
+		p2 = 0x01
+	} else {
+		p2 = 0x00
+	}
+	cmd, err := NewCommandExportKey(p1, p2, path)
+	if err != nil {
+		return nil, err
+	}	
+
+	resp, err := cs.sc.Send(cmd)
+	// fmt.Printf("res.Data: %x\n", resp.Data)
+	err = cs.checkOK(resp, err)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+
+}
+
 func (cs *CommandSet) SetPinlessPath(path string) error {
 	cmd, err := NewCommandSetPinlessPath(path)
 	if err != nil {

--- a/commands.go
+++ b/commands.go
@@ -30,8 +30,8 @@ const (
 	P1GetStatusApplication     = 0x00
 	P1GetStatusKeyPath         = 0x01
 	P1DeriveKeyFromMaster      = 0x00
-	P1DeriveKeyFromParent      = 0x01
-	P1DeriveKeyFromCurrent     = 0x10
+	P1DeriveKeyFromParent      = 0x40
+	P1DeriveKeyFromCurrent     = 0x80
 	P1ChangePinPIN             = 0x00
 	P1ChangePinPUK             = 0x01
 	P1ChangePinPairingSecret   = 0x02

--- a/commands.go
+++ b/commands.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-
 	"github.com/status-im/keycard-go/apdu"
 	"github.com/status-im/keycard-go/derivationpath"
 	"github.com/status-im/keycard-go/globalplatform"
+	"github.com/status-im/keycard-go/types"
 )
 
 const (
@@ -222,7 +222,7 @@ func NewCommandExportKey(p1 uint8, p2 uint8, pathStr string) (*apdu.Command, err
 	
 	// Choose to derive based on the value of p1
 	data := new(bytes.Buffer)
-	if (p1 == 0x01 || p1 == 0x02) {
+	if (p1 == types.EXPORT_KEY_DERIVE || p1 == types.EXPORT_KEY_DERIVE_AND_MAKE_CURRENT) {
 		_, path, err := derivationpath.Decode(pathStr)
 		if err != nil {
 			return nil, err

--- a/commands.go
+++ b/commands.go
@@ -7,7 +7,6 @@ import (
 	"github.com/status-im/keycard-go/apdu"
 	"github.com/status-im/keycard-go/derivationpath"
 	"github.com/status-im/keycard-go/globalplatform"
-	"github.com/status-im/keycard-go/types"
 )
 
 const (
@@ -42,6 +41,12 @@ const (
 	P1SignPinless              = 0x03
 
 	SwNoAvailablePairingSlots = 0x6A84
+
+	EXPORT_KEY_CURRENT                 = uint8(0x00)
+	EXPORT_KEY_DERIVE                  = uint8(0x01)
+	EXPORT_KEY_DERIVE_AND_MAKE_CURRENT = uint8(0x02)
+	EXPORT_KEY_PRIV_PUB                = uint8(0x00)
+	EXPORT_KEY_PUB                     = uint8(0x01)
 )
 
 func NewCommandInit(data []byte) *apdu.Command {
@@ -180,16 +185,9 @@ func NewCommandDeriveKey(pathStr string) (*apdu.Command, error) {
 		return nil, err
 	}
 
-	var p1 uint8
-	switch startingPoint {
-	case derivationpath.StartingPointMaster:
-		p1 = P1DeriveKeyFromMaster
-	case derivationpath.StartingPointParent:
-		p1 = P1DeriveKeyFromParent
-	case derivationpath.StartingPointCurrent:
-		p1 = P1DeriveKeyFromCurrent
-	default:
-		return nil, fmt.Errorf("invalid startingPoint %d", startingPoint)
+	p1, err := _getDeriveP1(startingPoint)
+	if err != nil {
+		return nil, err
 	}
 
 	data := new(bytes.Buffer)
@@ -219,25 +217,27 @@ func NewCommandDeriveKey(pathStr string) (*apdu.Command, error) {
 //  @param {pathStr}
 //		Derivation path of format "m/x/x/x/x/x", e.g. "m/44'/0'/0'/0/0"
 func NewCommandExportKey(p1 uint8, p2 uint8, pathStr string) (*apdu.Command, error) {
-	
-	// Choose to derive based on the value of p1
+	startingPoint, path, err := derivationpath.Decode(pathStr)
+	if err != nil {
+		return nil, err
+	}
+
+	deriveP1, err := _getDeriveP1(startingPoint)
+	if err != nil {
+		return nil, err
+	}
+
 	data := new(bytes.Buffer)
-	if (p1 == types.EXPORT_KEY_DERIVE || p1 == types.EXPORT_KEY_DERIVE_AND_MAKE_CURRENT) {
-		_, path, err := derivationpath.Decode(pathStr)
-		if err != nil {
+	for _, segment := range path {
+		if err := binary.Write(data, binary.BigEndian, segment); err != nil {
 			return nil, err
-		}
-		for _, segment := range path {
-			if err := binary.Write(data, binary.BigEndian, segment); err != nil {
-				return nil, err
-			}
 		}
 	}
 
 	return apdu.NewCommand(
 		globalplatform.ClaGp,
 		InsExportKey,
-		p1,
+		p1 | deriveP1,
 		p2,
 		data.Bytes(),
 	), nil
@@ -281,4 +281,17 @@ func NewCommandSign(data []byte, p1 uint8) (*apdu.Command, error) {
 		0,
 		data,
 	), nil
+}
+
+func _getDeriveP1(s derivationpath.StartingPoint) (uint8, error) {
+	switch s {
+		case derivationpath.StartingPointMaster:
+			return P1DeriveKeyFromMaster, nil
+		case derivationpath.StartingPointParent:
+			return P1DeriveKeyFromParent, nil
+		case derivationpath.StartingPointCurrent:
+			return P1DeriveKeyFromCurrent, nil
+		default:
+			return uint8(0), fmt.Errorf("invalid startingPoint %d", s)
+	}
 }

--- a/commands.go
+++ b/commands.go
@@ -283,6 +283,8 @@ func NewCommandSign(data []byte, p1 uint8) (*apdu.Command, error) {
 	), nil
 }
 
+// Internal function. Get the type of starting point for the derivation path.
+// Used for both DeriveKey and ExportKey
 func _getDeriveP1(s derivationpath.StartingPoint) (uint8, error) {
 	switch s {
 		case derivationpath.StartingPointMaster:

--- a/types/types.go
+++ b/types/types.go
@@ -11,3 +11,9 @@ type PairingInfo struct {
 	Key   []byte
 	Index int
 }
+
+var EXPORT_KEY_CURRENT                 = uint8(0x00)
+var EXPORT_KEY_DERIVE                  = uint8(0x01)
+var EXPORT_KEY_DERIVE_AND_MAKE_CURRENT = uint8(0x02)
+var EXPORT_KEY_PRIV_PUB                = uint8(0x00)
+var EXPORT_KEY_PUB                     = uint8(0x01)

--- a/types/types.go
+++ b/types/types.go
@@ -11,9 +11,3 @@ type PairingInfo struct {
 	Key   []byte
 	Index int
 }
-
-var EXPORT_KEY_CURRENT                 = uint8(0x00)
-var EXPORT_KEY_DERIVE                  = uint8(0x01)
-var EXPORT_KEY_DERIVE_AND_MAKE_CURRENT = uint8(0x02)
-var EXPORT_KEY_PRIV_PUB                = uint8(0x00)
-var EXPORT_KEY_PUB                     = uint8(0x01)


### PR DESCRIPTION
This PR implements [EXPORT KEY](https://dev.status.im/keycard_api/apdu_exportkey.html)

* Adds command to pass `p1`, `p2`, and `path` array to the card applet
* Adds interface to said command, which splits parametrization into more logical booleans