### PR TITLE
use root uid due to docker user namespace

### DIFF
--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
     docker {
       label 'linux'
       image 'golang:1.12'
+      args  '-u 0:0'
     }
   }
 


### PR DESCRIPTION
Tiny fix for CI builds due to us using Docker user namespaces, which remaps UID `0` as `1001`(`jenkins`).