### PR TITLE
fix: secure channel mutex

### DIFF
--- a/secure_channel.go
+++ b/secure_channel.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"errors"
+	"sync"
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
 	"github.com/status-im/keycard-go/apdu"
 	"github.com/status-im/keycard-go/crypto"
 	"github.com/status-im/keycard-go/globalplatform"
@@ -23,11 +25,13 @@ type SecureChannel struct {
 	encKey    []byte
 	macKey    []byte
 	iv        []byte
+	mutex     sync.Mutex
 }
 
 func NewSecureChannel(c types.Channel) *SecureChannel {
 	return &SecureChannel{
-		c: c,
+		c:     c,
+		mutex: sync.Mutex{},
 	}
 }
 
@@ -53,6 +57,9 @@ func (sc *SecureChannel) Reset() {
 }
 
 func (sc *SecureChannel) Init(iv, encKey, macKey []byte) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+
 	sc.iv = iv
 	sc.encKey = encKey
 	sc.macKey = macKey
@@ -73,6 +80,9 @@ func (sc *SecureChannel) RawPublicKey() []byte {
 
 func (sc *SecureChannel) Send(cmd *apdu.Command) (*apdu.Response, error) {
 	if sc.open {
+		sc.mutex.Lock()
+		defer sc.mutex.Unlock()
+
 		encData, err := crypto.EncryptData(cmd.Data, sc.encKey, sc.iv)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

When using secure channel in a multi-thread environment, it is possible that `Send` is called from 2 go-routines.
In such case, we must ensure that secure channel IV is updated before sending the next message.

The bug is easily reproduced when calling `ExportKey` and `GetMetadata` simultaneously. 

Despite the fact that `status-keycard-go` keeps the proper APDU/RPDU order, and doesn't allow them to get mixed, we also need to **ensure that the RPDU is parsed before the next APDU is prepared**, to keep the secure channel work properly.

This PR prevents solutions like this in status-desktop: https://github.com/status-im/status-desktop/pull/17337#discussion_r1963416829

# Reproduce

To reproduce the bug, I did this using `status-keycard-go/cmd/status-keycard-server`
1. `Start`
2. Insert the reader and the keycard
3. `Authorize`
4. Simultaneously call `GetMetadata` and `ExportLoginKeys` (I did it using a [compound target](https://www.jetbrains.com/help/go/run-debug-multiple.html#compound-configs) in GoLand)
<img width="648" alt="image" src="https://github.com/user-attachments/assets/98c6224c-3a5c-4e52-82df-5b1e99d71d56" />
